### PR TITLE
Improve site filtering for Syracuse datacenter example

### DIFF
--- a/netbox_server.py
+++ b/netbox_server.py
@@ -70,11 +70,13 @@ ALLOWED_FILTERS = {
     "racks": {"site", "status", "role", "tag", "q"},
     "devices": {"site", "rack", "role", "status", "manufacturer", "tag", "q"},
     "ip-addresses": {"address", "vrf", "status", "q"},
+    "sites": {"name", "slug", "status", "region", "tag", "q"},
     # Add more as needed...
 }
 
 FRIENDLY_FILTERS = {
-    "site_name": "site", "datacenter": "site", "rack_role": "role", "device_type": "type", "ip": "address", "search": "q"
+    "site_name": "site", "datacenter": "site", "rack_role": "role", "device_type": "type", "ip": "address", "search": "q",
+    "site_slug": "slug", "datacenter_name": "name"
 }
 
 def normalize_object_type(obj_type: str) -> str:

--- a/openai_netbox_client.py
+++ b/openai_netbox_client.py
@@ -195,6 +195,16 @@ async def main():
                     function_name = tool_call.function.name
                     args = json.loads(tool_call.function.arguments)
 
+                    # If the assistant requests site data without a filter,
+                    # add one to narrow the results to the Syracuse datacenter.
+                    if (
+                        function_name == "netbox_get_objects"
+                        and args.get("object_type") == "sites"
+                        and not args.get("filters")
+                    ):
+                        args["filters"] = {"name": "Syracuse"}
+                        print("Applying site name filter for Syracuse")
+
                     result = await session.call_tool(function_name, arguments=args)
                     print(f"\n🔹 Executed {function_name} with args {args}\n🔸 Result: {result.content[0].text}")
 


### PR DESCRIPTION
## Summary
- allow filtering `sites` objects by name or slug in `netbox_server`
- add a friendly filter alias for site slug and datacenter name
- ensure the example client applies a Syracuse filter if none is supplied

## Testing
- `python -m py_compile netbox_server.py openai_netbox_client.py netbox_client.py`

------
https://chatgpt.com/codex/tasks/task_e_685b1ec72e5c8321b2f0fc983db3b89a